### PR TITLE
adding check for `aws` cli (fixes #14)

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -11,7 +11,7 @@ publickey=id_rsa.pub
 groupName=luftballons-sg
 instanceName=luftballon
 
-aws --version || installAwsCli.sh
+aws --version || ../installAwsCli.sh
 
 function importSshKey()
 {

--- a/start.sh
+++ b/start.sh
@@ -11,6 +11,7 @@ publickey=id_rsa.pub
 groupName=luftballons-sg
 instanceName=luftballon
 
+aws --version || echo "Run installAwsCli.sh first. AWS CLI is not installed." && exit 1
 
 function importSshKey()
 {
@@ -119,7 +120,7 @@ treehouses config add groupName $groupName
 echo "Store Group Name"
 
 echo "Add name "$instanceName" on EC2 instance"
-aws ec2 create-tags --resources $instanceId --tags Key=Name,Value=$instanceName || echo "Run installAwsCli.sh first. AWS CLI is not installed." && exit 1
+aws ec2 create-tags --resources $instanceId --tags Key=Name,Value=$instanceName
 
 echo "Will open ssh tunnel soon"
 isOpen=$(ssh-keyscan -H $publicIp | grep ecdsa-sha2-nistp256)

--- a/start.sh
+++ b/start.sh
@@ -11,7 +11,7 @@ publickey=id_rsa.pub
 groupName=luftballons-sg
 instanceName=luftballon
 
-aws --version || echo "Run installAwsCli.sh first. AWS CLI is not installed." && exit 1
+aws --version || installAwsCli.sh
 
 function importSshKey()
 {

--- a/start.sh
+++ b/start.sh
@@ -11,7 +11,7 @@ publickey=id_rsa.pub
 groupName=luftballons-sg
 instanceName=luftballon
 
-aws --version || ../installAwsCli.sh
+aws --version || ./installAwsCli.sh
 
 function importSshKey()
 {

--- a/start.sh
+++ b/start.sh
@@ -11,7 +11,7 @@ publickey=id_rsa.pub
 groupName=luftballons-sg
 instanceName=luftballon
 
-aws --version || ./installAwsCli.sh || echo "Run installAwsCli.sh first. AWS CLI is not installed." && exit 1
+aws --version || echo "Run './installAwsCli.sh' first. AWS CLI is not installed." && exit 1
 
 function importSshKey()
 {

--- a/start.sh
+++ b/start.sh
@@ -11,7 +11,7 @@ publickey=id_rsa.pub
 groupName=luftballons-sg
 instanceName=luftballon
 
-aws --version || ./installAwsCli.sh
+aws --version || ./installAwsCli.sh || echo "Run installAwsCli.sh first. AWS CLI is not installed." && exit 1
 
 function importSshKey()
 {

--- a/start.sh
+++ b/start.sh
@@ -119,7 +119,7 @@ treehouses config add groupName $groupName
 echo "Store Group Name"
 
 echo "Add name "$instanceName" on EC2 instance"
-aws ec2 create-tags --resources $instanceId --tags Key=Name,Value=$instanceName
+aws ec2 create-tags --resources $instanceId --tags Key=Name,Value=$instanceName || echo "Run installAwsCli.sh first. AWS CLI is not installed." && exit 1
 
 echo "Will open ssh tunnel soon"
 isOpen=$(ssh-keyscan -H $publicIp | grep ecdsa-sha2-nistp256)


### PR DESCRIPTION
start.sh now checks if AWS CLI is installed, attempts an install, and displays an error output on install failure to instruct how to AWS CLI:
`aws --version || ./installAwsCli.sh || echo "Run installAwsCli.sh first. AWS CLI is not installed." && exit 1`